### PR TITLE
gmatch not available in twow API

### DIFF
--- a/NecrosisInitialize.lua
+++ b/NecrosisInitialize.lua
@@ -71,7 +71,7 @@ local function Necrosis_ParseVersion(version)
 	if type(version) ~= "string" then
 		version = tostring(version or "")
 	end
-	for token in string.gmatch(version, "%d+") do
+	for token in string.gfind(version, "%d+") do
 		table.insert(values, tonumber(token) or 0)
 	end
 	return values

--- a/NecrosisShardDial.lua
+++ b/NecrosisShardDial.lua
@@ -75,7 +75,7 @@ end
 
 local function removeFlag(flags, flag)
 	local parsed = {}
-	for part in string.gmatch(normaliseFlags(flags), "%S+") do
+	for part in string.gfind(normaliseFlags(flags), "%S+") do
 		if part ~= flag then
 			table.insert(parsed, part)
 		end
@@ -91,7 +91,7 @@ local function addFlag(flags, flag)
 	if not flag or flag == "" then
 		return base
 	end
-	for part in string.gmatch(base, "%S+") do
+	for part in string.gfind(base, "%S+") do
 		if part == flag then
 			return base
 		end


### PR DESCRIPTION
I'm pretty new to lua, addons, and twow, but I was seeing `attempt to call field gmatch a nil value` spammed when I installed this addon. Doing some research it seems like this function does not exist in the `string` API for the version of lua that twow has (5.0) so it fails to find this function.

I'm not sure how I'm the first person to see this, but this is the fix I found to work. I have not done extensive testing

I loved this addon back in my vanilla days so thanks for porting it!